### PR TITLE
Metadata load event

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,3 +269,7 @@ public function create(#[SerializeParam] Topic $topic): JsonResponse
     );
 }
 ```
+
+### Events
+
+- `anzu_systems_serializer.load_metadata` is called after the class metadata are loaded

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "doctrine/common": "^3.3"
+        "doctrine/common": "^3.3",
+        "symfony/event-dispatcher": "^5.3|^6.0|^7.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.10",

--- a/src/DependencyInjection/AnzuSystemsSerializerExtension.php
+++ b/src/DependencyInjection/AnzuSystemsSerializerExtension.php
@@ -124,6 +124,7 @@ final class AnzuSystemsSerializerExtension extends Extension
                 ->setArgument('$appCache', new Reference(CacheItemPoolInterface::class))
                 ->setArgument('$appLogger', new Reference(LoggerInterface::class))
                 ->setArgument('$metadataFactory', new Reference(MetadataFactory::class))
+                ->setArgument('$eventDispatcher', new Reference('event_dispatcher'))
         );
 
         $container->setDefinition(

--- a/src/Event/LoadMetadataEvent.php
+++ b/src/Event/LoadMetadataEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AnzuSystems\SerializerBundle\Event;
+
+use AnzuSystems\SerializerBundle\Metadata\ClassMetadata;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class LoadMetadataEvent extends Event
+{
+    public const NAME = 'anzu_systems_serializer.load_metadata';
+
+    public function __construct(
+        protected ClassMetadata $classMetadata,
+    ) {
+    }
+
+    public function getClassMetadata(): ClassMetadata
+    {
+        return $this->classMetadata;
+    }
+}

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AnzuSystems\SerializerBundle\Metadata;
+
+use AnzuSystems\SerializerBundle\Exception\SerializerException;
+
+final class ClassMetadata
+{
+    /**
+     * @param array<string, Metadata> $metadata
+     */
+    public function __construct(
+        private array $metadata
+    ) {
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->metadata[$name]);
+    }
+
+    public function get(string $name): Metadata
+    {
+        if (!isset($this->metadata[$name])) {
+            throw new SerializerException(sprintf('Metadata "%s" does not exist.', $name));
+        }
+
+        return $this->metadata[$name];
+    }
+
+    public function set(string $name, Metadata $metadata): self
+    {
+        $this->metadata[$name] = $metadata;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, Metadata>
+     */
+    public function getAll(): array
+    {
+        return $this->metadata;
+    }
+}

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -28,7 +28,7 @@ final class MetadataFactory
      *
      * @throws SerializerException
      */
-    public function buildMetadata(string $className): array
+    public function buildMetadata(string $className): ClassMetadata
     {
         try {
             $reflection = new ReflectionClass($className);
@@ -39,9 +39,11 @@ final class MetadataFactory
             throw new SerializerException('Cannot create reflection for ' . $className, 0, $exception);
         }
 
-        return array_merge(
-            $this->buildPropertyMetadata($reflection),
-            $this->buildMethodMetadata($reflection)
+        return new ClassMetadata(
+            array_merge(
+                $this->buildPropertyMetadata($reflection),
+                $this->buildMethodMetadata($reflection)
+            )
         );
     }
 

--- a/src/OpenApi/SerializerModelDescriber.php
+++ b/src/OpenApi/SerializerModelDescriber.php
@@ -153,7 +153,7 @@ final class SerializerModelDescriber implements ModelDescriberInterface
         $className = $model->getType()->getClassName();
         if ($className && class_exists($className)) {
             try {
-                return $this->metadataRegistry->get($className);
+                return $this->metadataRegistry->get($className)->getAll();
             } catch (SerializerException) {
                 return [];
             }

--- a/src/Request/ParamConverter/SerializerParamConverter.php
+++ b/src/Request/ParamConverter/SerializerParamConverter.php
@@ -11,7 +11,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInte
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * @deprecated Use SerializerValueResolver::class instead.
+ * @deprecated Use {@link SerializerValueResolver} instead.
  */
 final class SerializerParamConverter implements ParamConverterInterface
 {

--- a/src/Service/JsonDeserializer.php
+++ b/src/Service/JsonDeserializer.php
@@ -7,6 +7,7 @@ namespace AnzuSystems\SerializerBundle\Service;
 use AnzuSystems\SerializerBundle\Exception\DeserializationException;
 use AnzuSystems\SerializerBundle\Exception\SerializerException;
 use AnzuSystems\SerializerBundle\Handler\HandlerResolver;
+use AnzuSystems\SerializerBundle\Metadata\Metadata;
 use AnzuSystems\SerializerBundle\Metadata\MetadataRegistry;
 use Doctrine\Common\Collections\Collection;
 use JsonException;
@@ -75,9 +76,10 @@ final class JsonDeserializer
      */
     private function arrayToObject(array $data, string $className): object
     {
-        $objectMetadata = $this->metadataRegistry->get($className);
+        $objectMetadata = $this->metadataRegistry->get($className)->getAll();
         $object = new $className();
         foreach ($objectMetadata as $name => $metadata) {
+            /** @var Metadata $metadata */
             if (null === $metadata->setter || false === array_key_exists($name, $data)) {
                 continue;
             }

--- a/src/Service/JsonSerializer.php
+++ b/src/Service/JsonSerializer.php
@@ -63,7 +63,8 @@ final class JsonSerializer
     private function objectToArray(object $data): array
     {
         $output = [];
-        foreach ($this->metadataRegistry->get($data::class) as $name => $metadata) {
+        foreach ($this->metadataRegistry->get($data::class)->getAll() as $name => $metadata) {
+            /** @var Metadata $metadata */
             $value = $data->{$metadata->getter}();
             $output[$name] = $this->handlerResolver
                 ->getSerializationHandler($value, $metadata->customHandler)


### PR DESCRIPTION
Based on #15 

This PR adds support for dispatching `LoadMetadataEvent` (like doctrine's [LoadClassMetadataEventArgs](https://www.doctrine-project.org/projects/doctrine-orm/en/2.17/reference/events.html#load-classmetadata-event)). This event can be used in some edge cases to modify the class metadata. 