### PR TITLE
Add `SerializationContext`, allow to deserialize classes with constructor params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # Env files
 .env.local
+.env.test
 .env.local.php
 .env.*.local
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ To create a custom handler, simply extend the `AnzuSystems\SerializerBundle\Hand
 For instance in the following example a Geolocation class is converted to/from array:
 
 ```php
+use AnzuSystems\SerializerBundle\Context\SerializationContext;
 use AnzuSystems\SerializerBundle\Handler\Handlers\AbstractHandler;
 
 final class GeolocationHandler extends AbstractHandler
@@ -139,7 +140,7 @@ final class GeolocationHandler extends AbstractHandler
     /**
      * @param Geolocation $value
      */
-    public function serialize(mixed $value, Metadata $metadata): array
+    public function serialize(mixed $value, Metadata $metadata, SerializationContext $context): string): array
     {
         return [
             'lat' => $value->getLatitude(),

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -1,0 +1,16 @@
+UPGRADE FROM 3.x to 4.0
+=======================
+
+Add parameter `SerializationContext $context` to method `serialize()` in all your serializer handlers.
+
+Before:
+
+```php
+public function serialize(mixed $value, Metadata $metadata): mixed;
+```
+
+After:
+
+```php
+public function serialize(mixed $value, Metadata $metadata, SerializationContext $context): mixed;
+```

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "doctrine/common": "^3.3"
+        "doctrine/common": "^3.3",
+        "symfony/property-info": "^6.3|^7.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.10",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-json": "*",
         "doctrine/common": "^3.3",
         "symfony/property-info": "^6.3|^7.0"

--- a/psalm.xml
+++ b/psalm.xml
@@ -23,6 +23,7 @@
 
     <issueHandlers>
         <MoreSpecificImplementedParamType errorLevel="suppress"/>
+        <RiskyTruthyFalsyComparison errorLevel="suppress"/>
         <UnnecessaryVarAnnotation errorLevel="suppress"/> <!-- PHPStorm doesn't understand to generics annotations yet -->
 
         <UnusedFunctionCall>

--- a/src/Context/SerializationContext.php
+++ b/src/Context/SerializationContext.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AnzuSystems\SerializerBundle\Context;
+
+final class SerializationContext
+{
+    private bool $serializeNulls = true;
+
+    public function setSerializeNulls(bool $serializeNulls): self
+    {
+        $this->serializeNulls = $serializeNulls;
+
+        return $this;
+    }
+
+    /**
+     * Returns true when NULLs should be serialized.
+     */
+    public function shouldSerializeNull(): bool
+    {
+        return $this->serializeNulls;
+    }
+
+    public static function create(): self
+    {
+        return new self();
+    }
+}

--- a/src/Handler/HandlerResolver.php
+++ b/src/Handler/HandlerResolver.php
@@ -25,7 +25,7 @@ final class HandlerResolver
     public function getSerializationHandler(mixed $value, ?string $customHandler): HandlerInterface
     {
         try {
-            if ($customHandler) {
+            if (null !== $customHandler && '' !== $customHandler) {
                 return $this->handlerLocator->get($customHandler);
             }
             /** @var class-string<HandlerInterface> $handler */
@@ -50,7 +50,7 @@ final class HandlerResolver
         ?string $customHandler
     ): HandlerInterface {
         try {
-            if ($customHandler) {
+            if (null !== $customHandler && '' !== $customHandler) {
                 return $this->handlerLocator->get($customHandler);
             }
             /** @var class-string<HandlerInterface> $handler */
@@ -72,7 +72,7 @@ final class HandlerResolver
     public function getDescriptionHandler(string $property, Metadata $metadata): HandlerInterface
     {
         try {
-            if ($metadata->customHandler) {
+            if (null !== $metadata->customHandler && '' !== $metadata->customHandler) {
                 return $this->handlerLocator->get($metadata->customHandler);
             }
 

--- a/src/Handler/HandlerResolver.php
+++ b/src/Handler/HandlerResolver.php
@@ -25,7 +25,7 @@ final class HandlerResolver
     public function getSerializationHandler(mixed $value, ?string $customHandler): HandlerInterface
     {
         try {
-            if (null !== $customHandler && '' !== $customHandler) {
+            if (false === empty($customHandler)) {
                 return $this->handlerLocator->get($customHandler);
             }
             /** @var class-string<HandlerInterface> $handler */
@@ -50,7 +50,7 @@ final class HandlerResolver
         ?string $customHandler
     ): HandlerInterface {
         try {
-            if (null !== $customHandler && '' !== $customHandler) {
+            if (false === empty($customHandler)) {
                 return $this->handlerLocator->get($customHandler);
             }
             /** @var class-string<HandlerInterface> $handler */

--- a/src/Handler/Handlers/AbstractHandler.php
+++ b/src/Handler/Handlers/AbstractHandler.php
@@ -44,7 +44,7 @@ abstract class AbstractHandler implements HandlerInterface
         }
         if (Type::BUILTIN_TYPE_ARRAY === $metadata->type) {
             $itemType = [];
-            if ($metadata->customType) {
+            if (null !== $metadata->customType && '' !== $metadata->customType) {
                 $itemType = ['type' => $metadata->customType];
             }
             $description['items'] = $itemType;

--- a/src/Handler/Handlers/ArrayStringHandler.php
+++ b/src/Handler/Handlers/ArrayStringHandler.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace AnzuSystems\SerializerBundle\Handler\Handlers;
 
+use AnzuSystems\SerializerBundle\Context\SerializationContext;
 use AnzuSystems\SerializerBundle\Exception\SerializerException;
 use AnzuSystems\SerializerBundle\Metadata\Metadata;
 use Symfony\Component\PropertyInfo\Type;
 
 final class ArrayStringHandler extends AbstractHandler
 {
-    public function serialize(mixed $value, Metadata $metadata): string
+    public function serialize(mixed $value, Metadata $metadata, SerializationContext $context): string
     {
         if (is_array($value)) {
             return implode(',', $value);

--- a/src/Handler/Handlers/BasicHandler.php
+++ b/src/Handler/Handlers/BasicHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AnzuSystems\SerializerBundle\Handler\Handlers;
 
+use AnzuSystems\SerializerBundle\Context\SerializationContext;
 use AnzuSystems\SerializerBundle\Metadata\Metadata;
 use Symfony\Component\PropertyInfo\Type;
 
@@ -26,7 +27,7 @@ final class BasicHandler extends AbstractHandler
         return is_scalar($value) || null === $value;
     }
 
-    public function serialize(mixed $value, Metadata $metadata): string|int|bool|null|float
+    public function serialize(mixed $value, Metadata $metadata, SerializationContext $context): string|int|bool|null|float
     {
         return $value;
     }

--- a/src/Handler/Handlers/DateTimeHandler.php
+++ b/src/Handler/Handlers/DateTimeHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AnzuSystems\SerializerBundle\Handler\Handlers;
 
+use AnzuSystems\SerializerBundle\Context\SerializationContext;
 use AnzuSystems\SerializerBundle\Exception\DeserializationException;
 use AnzuSystems\SerializerBundle\Metadata\Metadata;
 use DateTime;
@@ -27,7 +28,7 @@ final class DateTimeHandler extends AbstractHandler
     /**
      * @param DateTimeInterface $value
      */
-    public function serialize(mixed $value, Metadata $metadata): string
+    public function serialize(mixed $value, Metadata $metadata, SerializationContext $context): string
     {
         return $value->format($metadata->customType ?? $this->serializerDateFormat);
     }

--- a/src/Handler/Handlers/EntityIdHandler.php
+++ b/src/Handler/Handlers/EntityIdHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AnzuSystems\SerializerBundle\Handler\Handlers;
 
 use AnzuSystems\SerializerBundle\Attributes\Serialize;
+use AnzuSystems\SerializerBundle\Context\SerializationContext;
 use AnzuSystems\SerializerBundle\Exception\SerializerException;
 use AnzuSystems\SerializerBundle\Helper\SerializerHelper;
 use AnzuSystems\SerializerBundle\Metadata\Metadata;
@@ -24,7 +25,7 @@ final class EntityIdHandler extends AbstractHandler
     ) {
     }
 
-    public function serialize(mixed $value, Metadata $metadata): array|object|int|null|string
+    public function serialize(mixed $value, Metadata $metadata, SerializationContext $context): array|object|int|null|string
     {
         if (null === $value) {
             return null;
@@ -44,7 +45,7 @@ final class EntityIdHandler extends AbstractHandler
         }
         if ($value instanceof Collection) {
             $ids = $value->map($toIdFunction);
-            if ($metadata->orderBy) {
+            if (null !== $metadata->orderBy) {
                 $ids = $this->getOrderedIDs($ids->getValues(), $metadata);
             }
             if (Serialize::KEYS_VALUES === $metadata->strategy) {

--- a/src/Handler/Handlers/EnumHandler.php
+++ b/src/Handler/Handlers/EnumHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AnzuSystems\SerializerBundle\Handler\Handlers;
 
+use AnzuSystems\SerializerBundle\Context\SerializationContext;
 use AnzuSystems\SerializerBundle\Exception\DeserializationException;
 use AnzuSystems\SerializerBundle\Exception\SerializerException;
 use AnzuSystems\SerializerBundle\Metadata\Metadata;
@@ -21,7 +22,7 @@ final class EnumHandler extends AbstractHandler
     /**
      * @param UnitEnum $value
      */
-    public function serialize(mixed $value, Metadata $metadata): int|string
+    public function serialize(mixed $value, Metadata $metadata, SerializationContext $context): int|string
     {
         if ($value instanceof BackedEnum) {
             return $value->value;

--- a/src/Handler/Handlers/HandlerInterface.php
+++ b/src/Handler/Handlers/HandlerInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AnzuSystems\SerializerBundle\Handler\Handlers;
 
 use AnzuSystems\SerializerBundle\AnzuSystemsSerializerBundle;
+use AnzuSystems\SerializerBundle\Context\SerializationContext;
 use AnzuSystems\SerializerBundle\Exception\SerializerException;
 use AnzuSystems\SerializerBundle\Metadata\Metadata;
 use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
@@ -23,7 +24,7 @@ interface HandlerInterface
     /**
      * @throws SerializerException
      */
-    public function serialize(mixed $value, Metadata $metadata): mixed;
+    public function serialize(mixed $value, Metadata $metadata, SerializationContext $context): mixed;
 
     /**
      * @throws SerializerException

--- a/src/Handler/Handlers/ObjectHandler.php
+++ b/src/Handler/Handlers/ObjectHandler.php
@@ -69,11 +69,11 @@ final class ObjectHandler extends AbstractHandler
             $collection = new ArrayCollection();
             foreach ($value as $key => $item) {
                 if (is_array($item)) {
-                    $val = $this->jsonDeserializer->fromArray($item, $this->getDeserializeCustomType($item, $metadata) ?? $metadata->type);
-                } else {
-                    $val = $item;
+                    $collection->set($key, $this->jsonDeserializer->fromArray($item, $this->getDeserializeCustomType($item, $metadata) ?? $metadata->type));
+
+                    continue;
                 }
-                $collection->set($key, $val);
+                $collection->set($key, $item);
             }
 
             return $collection;

--- a/src/Handler/Handlers/UuidHandler.php
+++ b/src/Handler/Handlers/UuidHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AnzuSystems\SerializerBundle\Handler\Handlers;
 
+use AnzuSystems\SerializerBundle\Context\SerializationContext;
 use AnzuSystems\SerializerBundle\Metadata\Metadata;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Uid\AbstractUid;
@@ -21,7 +22,7 @@ final class UuidHandler extends AbstractHandler
     /**
      * @param Uuid $value
      */
-    public function serialize(mixed $value, Metadata $metadata): string
+    public function serialize(mixed $value, Metadata $metadata, SerializationContext $context): string
     {
         return $value->toRfc4122();
     }

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -6,7 +6,7 @@ namespace AnzuSystems\SerializerBundle\Metadata;
 
 use AnzuSystems\SerializerBundle\Exception\SerializerException;
 
-final class ClassMetadata
+final readonly class ClassMetadata
 {
     /**
      * @param array<string, Metadata> $metadata
@@ -23,6 +23,9 @@ final class ClassMetadata
         return isset($this->metadata[$name]);
     }
 
+    /**
+     * @throws SerializerException
+     */
     public function get(string $name): Metadata
     {
         if (!isset($this->metadata[$name])) {
@@ -30,13 +33,6 @@ final class ClassMetadata
         }
 
         return $this->metadata[$name];
-    }
-
-    public function set(string $name, Metadata $metadata): self
-    {
-        $this->metadata[$name] = $metadata;
-
-        return $this;
     }
 
     /**

--- a/src/Metadata/ClassMetadata.php
+++ b/src/Metadata/ClassMetadata.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AnzuSystems\SerializerBundle\Metadata;
+
+use AnzuSystems\SerializerBundle\Exception\SerializerException;
+
+final class ClassMetadata
+{
+    /**
+     * @param array<string, Metadata> $metadata
+     * @param array<string, Metadata> $constructorMetadata
+     */
+    public function __construct(
+        private array $metadata,
+        private array $constructorMetadata
+    ) {
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->metadata[$name]);
+    }
+
+    public function get(string $name): Metadata
+    {
+        if (!isset($this->metadata[$name])) {
+            throw new SerializerException(sprintf('Metadata "%s" does not exist.', $name));
+        }
+
+        return $this->metadata[$name];
+    }
+
+    public function set(string $name, Metadata $metadata): self
+    {
+        $this->metadata[$name] = $metadata;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, Metadata>
+     */
+    public function getAll(): array
+    {
+        return $this->metadata;
+    }
+
+    /**
+     * @return array<string, Metadata>
+     */
+    public function getConstructorMetadata(): array
+    {
+        return $this->constructorMetadata;
+    }
+}

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -28,21 +28,58 @@ final class MetadataFactory
      *
      * @throws SerializerException
      */
-    public function buildMetadata(string $className): array
+    public function buildMetadata(string $className): ClassMetadata
     {
         try {
             $reflection = new ReflectionClass($className);
-            if ((int) $reflection->getConstructor()?->getNumberOfRequiredParameters() > 0) {
-                throw new SerializerException('Required constructor parameters found in ' . $className);
-            }
         } catch (ReflectionException $exception) {
             throw new SerializerException('Cannot create reflection for ' . $className, 0, $exception);
         }
 
-        return array_merge(
-            $this->buildPropertyMetadata($reflection),
-            $this->buildMethodMetadata($reflection)
+        return new ClassMetadata(
+            array_merge(
+                $this->buildPropertyMetadata($reflection),
+                $this->buildMethodMetadata($reflection)
+            ),
+            $this->buildConstructorMetadata($reflection),
         );
+    }
+
+    /**
+     * @throws SerializerException
+     */
+    private function buildConstructorMetadata(ReflectionClass $reflection): array
+    {
+        $constructorMethod = $reflection->getConstructor();
+        if (null === $constructorMethod) {
+            // the class has no constructor
+            return [];
+        }
+
+        if (!($constructorMethod->getModifiers() & ReflectionMethod::IS_PUBLIC)) {
+            // the class has private/protected constructor
+            return [];
+        }
+
+        $attribute = new Serialize();
+
+        $metadata = [];
+        foreach ($constructorMethod->getParameters() as $parameter) {
+            if ($parameter->isDefaultValueAvailable()) {
+                // we will use only the required parameters
+                continue;
+            }
+
+            $dataName = $attribute->serializedName ?? $parameter->getName();
+            $metadata[$dataName] = new Metadata(
+                (string) $parameter->getType(),
+                $parameter->allowsNull(),
+                '',
+                $parameter->getName(),
+            );
+        }
+
+        return $metadata;
     }
 
     /**
@@ -73,6 +110,7 @@ final class MetadataFactory
         $metadata = [];
         foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             $attributes = $method->getAttributes(Serialize::class);
+
             if (false === array_key_exists(0, $attributes)) {
                 continue;
             }
@@ -146,12 +184,19 @@ final class MetadataFactory
             }
         }
         $getter = $getterPrefix . ucfirst($property->getName());
-        if (false === $property->getDeclaringClass()->hasMethod($getter)) {
-            throw new SerializerException('Getter method ' . $getter . ' not found in ' . $property->getDeclaringClass()->getName() . '.');
+        $declaringClass = $property->getDeclaringClass();
+        if (false === $declaringClass->hasMethod($getter)) {
+            // fallback to "get" prefix
+            $getterFallback = 'get' . ucfirst($property->getName());
+            if (false === $declaringClass->hasMethod($getterFallback)) {
+                throw new SerializerException('Getter method ' . $getter . ' or ' . $getterFallback . ' not found in ' . $declaringClass->getName() . '.');
+            }
+
+            $getter = $getterFallback;
         }
         $setter = 'set' . ucfirst($property->getName());
-        if (false === $property->getDeclaringClass()->hasMethod($getter)) {
-            throw new SerializerException('Setter method ' . $setter . ' not found in ' . $property->getDeclaringClass()->getName() . '.');
+        if (false === $declaringClass->hasMethod($setter)) {
+            throw new SerializerException('Setter method ' . $setter . ' not found in ' . $declaringClass->getName() . '.');
         }
 
         return new Metadata(
@@ -174,6 +219,10 @@ final class MetadataFactory
      */
     private function resolveCustomType(Serialize $attribute): ?string
     {
+        if ('' === $attribute->type) {
+            return null;
+        }
+
         if ($attribute->type instanceof ContainerParam) {
             $paramName = $attribute->type->paramName;
             if ($this->parameterBag->has($paramName)) {

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -196,7 +196,8 @@ final class MetadataFactory
         }
         $setter = 'set' . ucfirst($property->getName());
         if (false === $declaringClass->hasMethod($setter)) {
-            throw new SerializerException('Setter method ' . $setter . ' not found in ' . $declaringClass->getName() . '.');
+            // setter is required for deserialization only
+            $setter = null;
         }
 
         return new Metadata(

--- a/src/Metadata/MetadataRegistry.php
+++ b/src/Metadata/MetadataRegistry.php
@@ -13,10 +13,10 @@ use Psr\Log\LoggerInterface;
 
 final class MetadataRegistry
 {
-    private const CACHE_PREFIX = 'anzu_ser_';
+    private const CACHE_PREFIX = 'anzu_serlz_';
 
     /**
-     * @var array<class-string, array<string, Metadata>>
+     * @var array<class-string, ClassMetadata>
      */
     private array $metadata = [];
 
@@ -30,16 +30,14 @@ final class MetadataRegistry
     /**
      * @param class-string $className
      *
-     * @return array<string, Metadata>
-     *
      * @throws SerializerException
      */
-    public function get(string $className): array
+    public function get(string $className): ClassMetadata
     {
         if (is_a($className, Proxy::class, true)) {
             $className = ClassUtils::getRealClass($className);
         }
-        if (false === array_key_exists($className, $this->metadata)) {
+        if (false === isset($this->metadata[$className])) {
             try {
                 $cachedItem = $this->appCache->getItem(self::CACHE_PREFIX . $className);
                 if ($cachedItem->isHit()) {

--- a/src/Metadata/MetadataRegistry.php
+++ b/src/Metadata/MetadataRegistry.php
@@ -13,7 +13,7 @@ use Psr\Log\LoggerInterface;
 
 final class MetadataRegistry
 {
-    private const CACHE_PREFIX = 'anzu_serlz_';
+    private const CACHE_PREFIX = 'anzu_serialz_';
 
     /**
      * @var array<class-string, ClassMetadata>

--- a/src/OpenApi/SerializerModelDescriber.php
+++ b/src/OpenApi/SerializerModelDescriber.php
@@ -45,6 +45,7 @@ final class SerializerModelDescriber implements ModelDescriberInterface
         $schema->type = Type::BUILTIN_TYPE_OBJECT;
         $properties = [];
         foreach ($this->getMetadata($model) as $propertyName => $metadata) {
+            /** @var Metadata $metadata */
             $handler = $this->handlerResolver->getDescriptionHandler($propertyName, $metadata);
             $description = $handler->describe($propertyName, $metadata);
 
@@ -61,7 +62,7 @@ final class SerializerModelDescriber implements ModelDescriberInterface
             $property = new Property($description);
 
             // Describe symfony constraints and property docBlock description.
-            if ($metadata->property && null !== $model->getType()->getClassName()) {
+            if (null !== $metadata->property && null !== $model->getType()->getClassName()) {
                 /** @psalm-suppress ArgumentTypeCoercion */
                 $propertyReflection = new ReflectionProperty($model->getType()->getClassName(), $metadata->property);
                 $this->getSymfonyConstraintAnnotationReader()->updateProperty($propertyReflection, $property);
@@ -83,6 +84,7 @@ final class SerializerModelDescriber implements ModelDescriberInterface
     private function getSymfonyConstraintAnnotationReader(): SymfonyConstraintAnnotationReader
     {
         if (null === $this->symfonyConstraintAnnotationReader) {
+            /** @psalm-suppress NullArgument */
             $this->symfonyConstraintAnnotationReader = new SymfonyConstraintAnnotationReader(null);
         }
 
@@ -92,7 +94,7 @@ final class SerializerModelDescriber implements ModelDescriberInterface
     private function addDocBlockDescription(ReflectionProperty|ReflectionMethod $reflection, Property $property): void
     {
         $docComment = $reflection->getDocComment();
-        if ($docComment) {
+        if (false !== $docComment) {
             $docComment = explode(PHP_EOL, $docComment);
 
             $firstKey = array_key_first($docComment);
@@ -163,9 +165,9 @@ final class SerializerModelDescriber implements ModelDescriberInterface
     private function getMetadata(Model $model): array
     {
         $className = $model->getType()->getClassName();
-        if ($className && class_exists($className)) {
+        if (null !== $className && '' !== $className && class_exists($className)) {
             try {
-                return $this->metadataRegistry->get($className);
+                return $this->metadataRegistry->get($className)->getAll();
             } catch (SerializerException) {
                 return [];
             }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AnzuSystems\SerializerBundle;
 
+use AnzuSystems\SerializerBundle\Context\SerializationContext;
 use AnzuSystems\SerializerBundle\Exception\SerializerException;
 use AnzuSystems\SerializerBundle\Service\JsonDeserializer;
 use AnzuSystems\SerializerBundle\Service\JsonSerializer;
@@ -44,6 +45,10 @@ final class Serializer
      */
     public function deserializeIterable(string $data, string $className, iterable $iterable): iterable
     {
+        if ('[]' === $data || '{}' === $data) {
+            return $iterable;
+        }
+
         return $this->jsonDeserializer->deserialize($data, $className, $iterable);
     }
 
@@ -78,16 +83,24 @@ final class Serializer
     /**
      * @throws SerializerException
      */
-    public function serialize(object|iterable $data): string
+    public function serialize(object|iterable $data, ?SerializationContext $context = null): string
     {
-        return $this->jsonSerializer->serialize($data);
+        if (null === $context) {
+            $context = SerializationContext::create();
+        }
+
+        return $this->jsonSerializer->serialize($data, $context);
     }
 
     /**
      * @throws SerializerException
      */
-    public function toArray(object|iterable $data): array|object
+    public function toArray(object|iterable $data, ?SerializationContext $context = null): array|object
     {
-        return $this->jsonSerializer->toArray($data);
+        if (null === $context) {
+            $context = SerializationContext::create();
+        }
+
+        return $this->jsonSerializer->toArray($data, null, $context);
     }
 }

--- a/src/Service/JsonDeserializer.php
+++ b/src/Service/JsonDeserializer.php
@@ -109,6 +109,7 @@ final class JsonDeserializer
      */
     private function createObjectInstance(ClassMetadata $objectMetadata, string $className, array $data): object
     {
+        $propMetadata = $objectMetadata->getAll();
         $constructorMetadata = $objectMetadata->getConstructorMetadata();
         if (empty($constructorMetadata)) {
             // initialize object without parameters
@@ -119,10 +120,10 @@ final class JsonDeserializer
         $params = [];
         foreach ($constructorMetadata as $name => $metadata) {
             /** @var Metadata $metadata */
-            if (false === isset($data[$name])) {
+            if (false === isset($data[$name], $propMetadata[$name])) {
                 throw new SerializerException(
                     sprintf(
-                        'Unable to deserialize "%s". Required constructor property "%s" missing in data.',
+                        'Unable to deserialize "%s". Required constructor property "%s" missing in data or serializable properties.',
                         $className,
                         $name
                     )

--- a/src/Service/JsonSerializer.php
+++ b/src/Service/JsonSerializer.php
@@ -37,8 +37,12 @@ final class JsonSerializer
     /**
      * @throws SerializerException
      */
-    public function toArray(object|iterable $data, ?Metadata $metadata = null, SerializationContext $context): array|object
+    public function toArray(object|iterable $data, ?Metadata $metadata = null, ?SerializationContext $context = null): array|object
     {
+        if (null === $context) {
+            $context = SerializationContext::create();
+        }
+
         if (is_iterable($data)) {
             $output = [];
             foreach ($data as $key => $item) {

--- a/tests/Controller/DummyControllerTest.php
+++ b/tests/Controller/DummyControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace AnzuSystems\SerializerBundle\Tests\Controller;

--- a/tests/Dto/BarDto.php
+++ b/tests/Dto/BarDto.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AnzuSystems\SerializerBundle\Tests\Dto;
+
+use AnzuSystems\SerializerBundle\Attributes\Serialize;
+
+final class BarDto
+{
+    #[Serialize]
+    private int $qux;
+
+    #[Serialize]
+    private string $quux;
+
+    public function __construct(int $qux, string $quux)
+    {
+        $this->qux = $qux;
+        $this->quux = $quux;
+    }
+
+    public function getQux(): int
+    {
+        return $this->qux;
+    }
+
+    public function setQux(int $qux): self
+    {
+        $this->qux = $qux;
+
+        return $this;
+    }
+
+    public function getQuux(): string
+    {
+        return $this->quux;
+    }
+
+    public function setQuux(string $quux): self
+    {
+        $this->quux = $quux;
+
+        return $this;
+    }
+}

--- a/tests/Dto/BazDto.php
+++ b/tests/Dto/BazDto.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AnzuSystems\SerializerBundle\Tests\Dto;
+
+use AnzuSystems\SerializerBundle\Attributes\Serialize;
+
+final class BazDto
+{
+    #[Serialize]
+    private int $qux;
+    private string $quux;
+
+    public function __construct(int $qux, string $quux)
+    {
+        $this->qux = $qux;
+        $this->quux = $quux;
+    }
+
+    public function getQux(): int
+    {
+        return $this->qux;
+    }
+
+    public function setQux(int $qux): self
+    {
+        $this->qux = $qux;
+
+        return $this;
+    }
+
+    public function getQuux(): string
+    {
+        return $this->quux;
+    }
+
+    public function setQuux(string $quux): self
+    {
+        $this->quux = $quux;
+
+        return $this;
+    }
+}

--- a/tests/Dto/BazDto.php
+++ b/tests/Dto/BazDto.php
@@ -23,22 +23,8 @@ final class BazDto
         return $this->qux;
     }
 
-    public function setQux(int $qux): self
-    {
-        $this->qux = $qux;
-
-        return $this;
-    }
-
     public function getQuux(): string
     {
         return $this->quux;
-    }
-
-    public function setQuux(string $quux): self
-    {
-        $this->quux = $quux;
-
-        return $this;
     }
 }

--- a/tests/Dto/FooDto.php
+++ b/tests/Dto/FooDto.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AnzuSystems\SerializerBundle\Tests\Dto;
+
+use AnzuSystems\SerializerBundle\Attributes\Serialize;
+use DateTimeImmutable;
+
+final class FooDto
+{
+    #[Serialize]
+    private int $bar;
+
+    #[Serialize]
+    private string $baz;
+
+    #[Serialize(serializedName: 'bar-dto')]
+    private BarDto $barDto;
+
+    #[Serialize]
+    private DateTimeImmutable $corge;
+
+    #[Serialize]
+    private bool $garply;
+
+    #[Serialize]
+    private ?string $fred = null;
+
+    // Should be ignored by serializer
+    private string $waldo = 'default-waldo-data';
+
+    public function __construct(int $bar, string $baz, BarDto $barDto)
+    {
+        $this->bar = $bar;
+        $this->baz = $baz;
+        $this->barDto = $barDto;
+    }
+
+    public function getBar(): int
+    {
+        return $this->bar;
+    }
+
+    public function setBar(int $bar): self
+    {
+        $this->bar = $bar;
+
+        return $this;
+    }
+
+    public function getBaz(): string
+    {
+        return $this->baz;
+    }
+
+    public function setBaz(string $baz): self
+    {
+        $this->baz = $baz;
+
+        return $this;
+    }
+
+    public function getBarDto(): BarDto
+    {
+        return $this->barDto;
+    }
+
+    public function setBarDto(BarDto $barDto): self
+    {
+        $this->barDto = $barDto;
+
+        return $this;
+    }
+
+    public function getCorge(): DateTimeImmutable
+    {
+        return $this->corge;
+    }
+
+    public function setCorge(DateTimeImmutable $corge): self
+    {
+        $this->corge = $corge;
+
+        return $this;
+    }
+
+    public function isGarply(): bool
+    {
+        return $this->garply;
+    }
+
+    public function setGarply(bool $garply): self
+    {
+        $this->garply = $garply;
+
+        return $this;
+    }
+
+    public function getFred(): ?string
+    {
+        return $this->fred;
+    }
+
+    public function setFred(?string $fred): self
+    {
+        $this->fred = $fred;
+
+        return $this;
+    }
+
+    public function getWaldo(): string
+    {
+        return $this->waldo;
+    }
+
+    public function setWaldo(string $waldo): self
+    {
+        $this->waldo = $waldo;
+
+        return $this;
+    }
+}

--- a/tests/SerializeDeserializeBasicTest.php
+++ b/tests/SerializeDeserializeBasicTest.php
@@ -7,6 +7,7 @@ namespace AnzuSystems\SerializerBundle\Tests;
 use AnzuSystems\SerializerBundle\Context\SerializationContext;
 use AnzuSystems\SerializerBundle\Exception\SerializerException;
 use AnzuSystems\SerializerBundle\Tests\Dto\BarDto;
+use AnzuSystems\SerializerBundle\Tests\Dto\BazDto;
 use AnzuSystems\SerializerBundle\Tests\Dto\FooDto;
 use AnzuSystems\SerializerBundle\Tests\TestApp\Entity\Example;
 use AnzuSystems\SerializerBundle\Tests\TestApp\Model\ExampleBackedEnum;
@@ -48,6 +49,21 @@ final class SerializeDeserializeBasicTest extends AbstractTestCase
         self::assertEquals($data, $deserialized);
     }
 
+    /**
+     * @throws SerializerException
+     *
+     * @dataProvider dataSerializeOnly
+     */
+    public function testSerializeOnly(string $expectedJson, string $json, object $data): void
+    {
+        $serialized = $this->serializer->serialize($data);
+        self::assertEquals($expectedJson, $serialized);
+
+        $this->expectException(SerializerException::class);
+        $this->expectExceptionMessage('Unable to deserialize "AnzuSystems\SerializerBundle\Tests\Dto\BazDto". Required constructor property "quux" missing in data or serializable properties');
+        $this->serializer->deserialize($json, $data::class);
+    }
+
     public function data(): iterable
     {
         yield [
@@ -85,6 +101,15 @@ final class SerializeDeserializeBasicTest extends AbstractTestCase
             (new FooDto(123_456, 'bar-bar', new BarDto(789_333, 'qux-qux')))
                 ->setCorge(new DateTimeImmutable('2024-05-10T00:00:00Z'))
                 ->setGarply(true),
+        ];
+    }
+
+    public function dataSerializeOnly(): iterable
+    {
+        yield [
+            '{"qux":789333}',
+            '{"qux":789333,"quux":"qux-qux"}',
+            (new BazDto(789_333, 'qux-qux')),
         ];
     }
 }

--- a/tests/SerializerValidationExceptionTest.php
+++ b/tests/SerializerValidationExceptionTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace AnzuSystems\SerializerBundle\Tests;
 
-use AnzuSystems\SerializerBundle\Exception\SerializerException;
 use AnzuSystems\SerializerBundle\Exception\DeserializationException;
 use AnzuSystems\SerializerBundle\Tests\TestApp\Entity\Example;
-use DateTimeImmutable;
 
 final class SerializerValidationExceptionTest extends AbstractTestCase
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,9 +8,9 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Dotenv\Dotenv;
 
-require dirname(__DIR__).'/vendor/autoload.php';
+require dirname(__DIR__) . '/vendor/autoload.php';
 
-(new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+(new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');
 
 $kernel = new AnzuTestKernel('test', false);
 $kernel->boot();


### PR DESCRIPTION
- allow to deserialze object with required parameters in constructor
- allow to skip nullable values in serialized string
- the metadata are stored in class
- added `SerializationContext`

BC break in HandlerInterface:

Before:
```
public function serialize(mixed $value, Metadata $metadata): mixed;
```

After:
```
public function serialize(mixed $value, Metadata $metadata, SerializationContext $context): mixed;
```